### PR TITLE
[ race ] Make `Either` be inside the racing primitive

### DIFF
--- a/tests/coop-monad/empty/002/expected
+++ b/tests/coop-monad/empty/002/expected
@@ -3,8 +3,8 @@ before coop
 [time: 0]                                                                       s77 proc, first
 [time: 0]                                                s35 proc, first
 [time: 0]                          s55 proc, first
-[time: 0] s150 proc, first
 [time: 0]                                                                       s77 proc, before 1350
+[time: 0] s150 proc, first
 [time: 0]                                                s35 proc, before 700
 [time: 0]                          s55 proc, before 350
 [time: 0] s150 proc, before 1000


### PR DESCRIPTION
This makes primitives for zipping and for racing looks very symmetric, in the form of `C a -> C b -> C (Tambara a b)` for particular tambaras of `Pair` and `Either` for zipping and racing respectively.